### PR TITLE
Add base dir to grunt launch

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -85,7 +85,9 @@ module.exports = function(grunt) {
 		},
 
 		server: {
-			port: 8888
+			port: 8888,
+			//base dir
+			base: './'
 		}
 
 	});


### PR DESCRIPTION
This commit adds base dir location to grunt launch. Therefore, once you start the server with **grunt launch** you can navigate to demo-build folder or check the demo app.
