### PR TITLE
In require 2.0.2+ urlMap is removed. Use "defined" instead.

### DIFF
--- a/src/aura/mediator.js
+++ b/src/aura/mediator.js
@@ -193,7 +193,7 @@ define(['dom', 'underscore'], function ($, _) {
 	//
 	// * **param:** {string} channel Event name
 	obj.unload = function (channel) {
-		var contextMap = require.s.contexts._.urlMap,
+		var contextMap = require.s.contexts._.defined,
 			key;
 		for (key in contextMap) {
 			if (contextMap.hasOwnProperty(key) && key.indexOf(channel) !== -1) {


### PR DESCRIPTION
The unload function did not remove widgets from require.
