### PR TITLE
Relative widget path in mediator

### DIFF
--- a/src/aura/mediator.js
+++ b/src/aura/mediator.js
@@ -125,7 +125,13 @@ define(['dom', 'underscore'], function ($, _) {
 		function load (file, element) {
 			var dfd = obj.data.deferred();
 
-			require(['../../../widgets/' + file + '/main'], function (main) {
+            var widgetsPath = '../../../widgets';
+            var requireConfig = require.s.contexts._.config;
+            if (requireConfig.paths && _.has(requireConfig.paths, 'widgets')) {
+                widgetsPath = requireConfig.paths.widgets;
+            }
+
+			require([widgetsPath + '/' + file + '/main'], function (main) {
 				try {
 					main(element);
 				} catch(e) {


### PR DESCRIPTION
The path that the aura core mediator uses for widgets is relative. This makes it hard to use aura inside another project as a dependency because widgets are probably in another directory.
I added a check to the mediator to look inside the require.js paths config for a path named "widgets". If it is present that path will be used to prefix widgets, else the default relative path will be used. 

I don't know if this is the best way to check the require.js config so if there is a better way I could change the pull request.
