### PR TITLE
Update src/config.js

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-require.config({
+var require = {
 	// shim underscore & backbone (cause we use the non AMD versions here)
 	shim: {
 		'dom': {
@@ -45,4 +45,4 @@ require.config({
 		// Demo App
 		perms: '../../../apps/demo/js/permissions'
 	}
-});
+};


### PR DESCRIPTION
Aura doesn't work in Opera and sometimes fails in IE9.
Opera loads files in a weird way, and when 'core' is required, it loads core.js
instead of mediator.js. This happens due to the fact that RequireJS 
doesn't have anything in require.config.paths. So require config can be global,
thus it works in Opera. And config should be loaded before require.js.
