### PR TITLE
Widgets path reflux

### DIFF
--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -69,6 +69,9 @@
           aura_perms: 'src/aura/permissions',
           aura_sandbox: 'src/aura/sandbox',
 
+          // Widgets
+          widgets: 'spec/js/widgets',
+
           text: 'src/extensions/backbone/lib/text',
           backbone: 'src/extensions/backbone/lib/backbone',
           localstorage: 'src/extensions/backbone/lib/localstorage',

--- a/spec/js/mediator_spec.js
+++ b/spec/js/mediator_spec.js
@@ -3,8 +3,12 @@ define(['aura_core'], function (core) {
 
     var mediator,
         getChannels,
-        TEST_CHANNEL = 'test';
+        TEST_CHANNEL = 'stub';
 
+    // Define stub widget main (to prevent RequireJS load errors)
+    define('spec/js/widgets/stub/main', function() {
+        return function () {};
+    });
 
     beforeEach(function() {
       mediator = core;
@@ -95,7 +99,7 @@ define(['aura_core'], function (core) {
 
       it('should call every callback for a channel, within the correct context', function () {
         var callback = sinon.spy();
-      
+
         channels[TEST_CHANNEL] = [
           {callback:callback}
         ];
@@ -120,7 +124,7 @@ define(['aura_core'], function (core) {
 
       it('should return false if channel has not been defined', function () {
         var called = mediator.emit(TEST_CHANNEL);
-        
+
         expect(called).toBe(false);
       });
 
@@ -128,7 +132,7 @@ define(['aura_core'], function (core) {
         channels[TEST_CHANNEL] = [
           {callback:function() {}}
         ];
-        
+
         mediator.start({ channel:TEST_CHANNEL, options: { element: '#nothing' } });
 
         mediator.emit(TEST_CHANNEL);

--- a/src/aura/core.js
+++ b/src/aura/core.js
@@ -17,7 +17,7 @@ define(['aura_base'], function(base) {
   var channels = {}; // Loaded modules and their callbacks
   var emitQueue = [];
   var isWidgetLoading = false;
-  var WIDGETS_PATH = '../../../widgets'; // Path to widgets
+  var WIDGETS_PATH = 'widgets'; // Path to widgets
 
   // Load in the base library, such as Zepto or jQuery. the following are
   // required for Aura to run:

--- a/src/config.js
+++ b/src/config.js
@@ -76,6 +76,9 @@ define(function() {
       aura_perms: '../../../aura/permissions',
       aura_sandbox: '../../../aura/sandbox',
 
+      // Widgets
+      widgets: "../../../widgets",
+
       // Backbone Extension
       core: '../../../extensions/backbone/core',
       sandbox: '../../../extensions/backbone/sandbox',


### PR DESCRIPTION
Core shouldn't have an opinion on where the widgets folder lies. Use a path config to point to widgets root. Applications should be able to put their widgets anywhere they want.

Also fixed the RequireJS load error caused by dummy "test" widget by defining a stub module.
