### PR TITLE
pubsub + perms: wildcards, namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     }
   },
   "devDependencies": {
-    "grunt": "~0.3.12",
+    "grunt": "~0.3.17",
     "grunt-requirejs": "~0.2.9",
     "grunt-contrib": "~0.1.7",
-    "grunt-jasmine-task": "~0.2.2"
+    "grunt-jasmine-task": "~0.2.3"
   },
   "scripts":{
     "test": "grunt build"

--- a/spec/SpecRunner.html
+++ b/spec/SpecRunner.html
@@ -57,6 +57,9 @@
           // Underscore (Lo-Dash - http://lodash.com)
           underscore: 'src/aura/lib/lodash',
 
+          // EventEmitter
+          eventemitter: 'src/aura/lib/eventemitter2',
+
           // Set the base library
           dom: 'src/aura/lib/dom',
 
@@ -76,6 +79,11 @@
           underscore: 'src/aura/lib/lodash',
           fullcalendar: 'src/extensions/backbone/lib/fullcalendar.min',
           jquery_ui: 'src/extensions/backbone/lib/jquery-ui.min'
+         },
+        config: {
+          'spec/js/mediator_spec': {
+            permissions: false
+          }
         }
     };
     require.config( require.aura );

--- a/spec/js/mediator_spec.js
+++ b/spec/js/mediator_spec.js
@@ -1,171 +1,378 @@
-define(['aura_core', 'aura_perms'], function (core, permissions) {
-  describe('Mediator', function () {
-
-    var mediator,
-        getChannels,
-        TEST_CHANNEL = 'stub';
-
-    // Define stub widget main (to prevent RequireJS load errors)
-    define('spec/js/widgets/stub/main', function() {
-        return function () {};
+    define('spec/js/widgets/test_widget/main', function() {
+      return function() {};
     });
 
-    // Bypass permissions
-    permissions.validate = function () {
-      return true;
-    };
+    define('spec/js/widgets/dummy_widget/main', function() {
+      return function() {};
+    });
 
-    beforeEach(function() {
-      mediator = core;
-      channels = mediator.getChannels();
+    define('spec/js/widgets/catchall_widget/main', function() {
+      return function() {};
+    });
+
+    define('spec/js/widgets/wildcard_widget/main', function() {
+      return function() {};
+    });
+
+    define('spec/js/widgets/single_perm_widget/main', function() {
+      return function() {};
+    });
+
+    define('perms', ['aura_perms'], function(permissions) {
+      'use strict';
+
+      permissions.extend({
+        test_widget: {
+          emit: ['stub.*'],
+          on: []
+        },
+        catchall_widget: ['*'],
+        wildcard_widget: {
+          emit: ['stub.*'],
+          on: ['test.**', 'test2ns.**'] // subscribe to wildcard events
+        },
+        single_perm_widget: ['test'] // loading via a single array will work for 'on' and 'emit'
+      });
+
+      return permissions;
+    });
+
+    define(['aura_core', 'aura_sandbox', 'perms', 'module'], function(mediator, sandbox, permissions, module) {
+      describe('PubSub', function() {
+        var SANDBOX_NAME = 'test_widget',
+          TEST_EVENT = 'stub';
+
+        mediator.getSandbox = function(sandbox) {
+          return sandbox;
+        };
 
         //override method util as it uses jQuery proxy and doesn't
         //allow comparison of actual callback function object.
-      mediator.util.method = function (fn, context) {
-        return fn;
-      };
+        mediator.util.method = function(fn, context) {
+          return fn;
+        };
 
-        //verify setup
-      expect(mediator).toBeDefined();
-      expect(channels).toBeDefined();
+        mediator.start([{
+          channel: SANDBOX_NAME,
+          options: {
+            element: '#todoapp'
+          }
+        }, {
+          channel: 'wildcard_widget',
+          options: {
+            element: '#hi'
+          }
+        },
 
-      delete channels[TEST_CHANNEL]; //clean our test channel
-    });
+        {
+          channel: 'catchall_widget',
+          options: {
+            element: '#hi3'
+          }
+        }, {
+          channel: 'single_perm_widget',
+          options: {
+            element: '#hi2'
+          }
+        }]);
 
-    describe('on', function() {
 
-      describe('verification of parameters', function() {
-        it('should throw an error if all the params are not specified', function () {
-          expect(function () {
-            mediator.on();
-          }).toThrow(new Error('Channel, callback, and context must be defined'));
+        beforeEach(function() {
+          // verify setup
+          expect(mediator).toBeDefined();
+          expect(mediator['pubsubs']).toBeDefined();
+
         });
 
-        it("should throw an error if typeof channel is NOT string", function() {
-          expect(function() {
-            mediator.on({}, 'subscriber', function () {}, {});
-          }).toThrow(new Error('Channel must be a string'));
+        describe('sandbox', function() {
+          describe('assign pubsubs upon start/stop of pubsubs', function() {
+            var dummy_widget = 'dummy_widget';
+            it('assign pubsub on sandbox start', function() {
+              runs(function() {
+                mediator.start([{
+                  channel: dummy_widget,
+                  options: {
+                    element: '#todoapp'
+                  }
+                }]);
+              });
+
+              waits(100); // wait for start's .load promise
+
+              runs(function() {
+                expect(mediator.pubsubs[dummy_widget]).toBeDefined();
+              });
+
+            });
+
+            it('destroy pubsub on sandbox stop', function() {
+              runs(function() {
+                mediator.start([{
+                  channel: dummy_widget,
+                  options: {
+                    element: '#todoapp'
+                  }
+                }]);
+              });
+              waits(100); // wait for start's .load promise
+
+              runs(function() {
+                expect(mediator.pubsubs[dummy_widget]).toBeDefined();
+              });
+
+              runs(function() {
+                mediator.stop(dummy_widget);
+                expect(mediator.pubsubs[dummy_widget]).not.toBeDefined();
+              });
+            });
+          });
+
+          describe('starting/stopping pubsubs', function() {
+
+            mediator.getPubSub('testpubsub');
+
+            it('should start pubsubs', function() {
+              mediator.getPubSub('testpubsub');
+
+              expect(mediator.pubsubs['testpubsub']).toBeDefined();
+
+            });
+
+            it('should destroy pubsubs', function() {
+              mediator.removePubSub('testpubsub');
+              expect(mediator.pubsubs['testpubsub']).not.toBeDefined();
+
+            });
+          });
+
         });
 
-        it("should throw an error if typeof subscriber is NOT string", function() {
-          expect(function() {
-            mediator.on('channel', {}, function(){}, {});
-          }).toThrow(new Error('Subscriber must be a string'));
+        describe('permissions', function() {
+          it('should load permissions declaratively via obj literal of \'emit\' and \'on\'', function() {
+            expect(mediator.hasPermission('emit', SANDBOX_NAME, 'stub.lol')).toBeTruthy();
+            expect(mediator.hasPermission('on', SANDBOX_NAME, 'stub.lol')).toBeFalsy();
+          });
+
+          it('should load permissions with single expression clause to both \'on\' and \'emit\'', function() {
+            expect(mediator.hasPermission('on', 'single_perm_widget', 'test')).toBeTruthy();
+            expect(mediator.hasPermission('emit', 'single_perm_widget', 'test')).toBeTruthy();
+          });
+
+          it('should load catch-all permissions', function() {
+            expect(mediator.hasPermission('on', 'catchall_widget', '*')).toBeTruthy();
+            expect(mediator.hasPermission('on', 'catchall_widget', 'hala')).toBeTruthy();
+            expect(mediator.hasPermission('on', 'catchall_widget', 'catch.everything.allday')).toBeTruthy();
+          });
+
+          it('should load * permissions', function() {
+            expect(mediator.hasPermission('on', 'wildcard_widget', 'test.*')).toBeTruthy();
+            expect(mediator.hasPermission('on', 'wildcard_widget', 'test.*.hey.notothis')).toBeFalsy();
+          });
+
+          it('should load ** permissions', function() {
+            expect(mediator.hasPermission('on', 'wildcard_widget', 'test.**')).toBeTruthy();
+            expect(mediator.hasPermission('on', 'wildcard_widget', 'nonsforthis.**')).toBeFalsy();
+          });
+
         });
 
-        it("should throw an error if typeof callback is NOT a function", function() {
-          expect(function() {
-            mediator.on('channel', 'subscriber', 'callback', {});
-          }).toThrow(new Error('Callback must be a function'));
+        describe('on', function() {
+
+          beforeEach(function() {
+            if (SANDBOX_NAME in mediator.pubsubs) {
+              mediator.removePubSub(SANDBOX_NAME);
+            }
+          });
+
+          describe('verification of parameters', function() {
+            it('should throw an error if all the params are not specified', function() {
+              expect(function() {
+                mediator.on();
+              }).toThrow(new Error('Event, subscriber, callback, and context must be defined'));
+            });
+
+            it("should throw an error if typeof event is NOT a string or array in EventEmitter format", function() {
+              expect(function() {
+                mediator.on({}, 'subscriber', function() {}, {});
+              }).toThrow(new Error('Event must be a string or array'));
+            });
+
+            it("should throw an error if typeof subscriber is NOT string. The subscriber should be the name of the sandbox widget", function() {
+              expect(function() {
+                mediator.on('event', {}, function() {}, {});
+              }).toThrow(new Error('The widget sandbox name must be passed as string'));
+            });
+
+            it("should throw an error if typeof callback is NOT a function", function() {
+              expect(function() {
+                mediator.on('channel', 'subscriber', 'callback', {});
+              }).toThrow(new Error('Callback must be a function'));
+            });
+          });
+
+          it('should allow an event to be subscribed', function() {
+            var pubsub = mediator.createPubSub(SANDBOX_NAME);
+            pubsub.on(TEST_EVENT, function() {}, this);
+            expect(pubsub.listeners(TEST_EVENT).length).toBe(1);
+          });
+
+          it('should be able assign a specific callback for subscribed event', function() {
+            var callback, callbackResult = 'callback';
+            var pubsub = mediator.createPubSub(SANDBOX_NAME);
+            pubsub.on(TEST_EVENT, function() {}, this);
+
+            pubsub.on(TEST_EVENT, function() {
+              return callbackResult;
+            }, this);
+
+            callback = pubsub.listeners(TEST_EVENT)[1];
+            expect(callback()).toBe(callbackResult);
+          });
+
+          it('should allow subscribing multiple callbacks for single event channel', function() {
+            var callback1 = function() {};
+            var callback2 = function() {};
+            var pubsub = mediator.createPubSub(SANDBOX_NAME);
+
+            pubsub.on(TEST_EVENT, callback1, this);
+            pubsub.on(TEST_EVENT, callback2, this);
+
+            //expect(channels[TEST_EVENT]).toContain(callback1, callback2);
+            expect(pubsub.listeners(TEST_EVENT).length).toBe(2);
+          });
+
+          it('should allow subscribing for catchall \'*\' events', function() {
+            var callback1 = function() {};
+            var pubsub = mediator.getPubSub('catchall_widget');
+
+            mediator.on('*', 'catchall_widget', callback1, this);
+            expect(pubsub.listenersAny().length).toBe(1);
+          });
+
+          describe('should allow namespaces and wildcards', function() {
+
+            it('should allow subscribing for namespaces, 2 level', function() {
+              var callback1 = function() {};
+              var pubsub = mediator.getPubSub('wildcard_widget');
+
+              mediator.on('test.dat', 'wildcard_widget', callback1, this);
+              expect(pubsub.listeners('test.dat').length).toBe(1);
+              expect(pubsub.listeners('test.*').length).toBe(1);
+              expect(pubsub.listeners('test.**').length).toBe(1);
+            });
+
+            it('should allow subscribing for namespaces, 3 level, wildcard', function() {
+              var callback1 = function() {};
+              var pubsub = mediator.getPubSub('wildcard_widget');
+
+              mediator.on('test.dis.ptrn', 'wildcard_widget', callback1, this);
+              expect(pubsub.listeners('test.dis.ptrn').length).toBe(1);
+              expect(pubsub.listeners('test.*.ptrn').length).toBe(1);
+              expect(pubsub.listeners('test.**.ptrn').length).toBe(1);
+            });
+
+            it('should allow subscribing for namespaces, 4 level, wildcard + **', function() {
+              var callback1 = function() {};
+              var pubsub = mediator.getPubSub('wildcard_widget');
+
+              mediator.on('test2ns.khal.drogo.no', 'wildcard_widget', callback1, this);
+              expect(pubsub.listeners('test2ns.khal.drogo.no').length).toBe(1);
+              expect(pubsub.listeners('test2ns.*.no').length).toBe(0);
+              expect(pubsub.listeners('test2ns.**.no').length).toBe(1);
+            });
+
+          });
+
+
         });
-      });
 
-      it('should allow an event to be subscribed', function() {
-        mediator.on(TEST_CHANNEL, 'spec', function() {}, this);
-          expect(channels[TEST_CHANNEL]).toBeDefined();
-        });
+        describe('emit', function() {
 
-      it('should be able assign a specific callback for subscribed event', function() {
-		var callback,
-			callbackResult = 'callback';
+          describe('verification of parameters', function() {
+            it('should throw an error if all the params are not specified', function() {
+              expect(function() {
+                mediator.emit();
+              }).toThrow(new Error('Event must be defined'));
+            });
 
-        mediator.on(TEST_CHANNEL, 'spec', function() { return callbackResult; }, this);
-        callback = channels[TEST_CHANNEL][0].callback;
-        expect(callback()).toBe(callbackResult);
-      });
+            it('should throw an error if typeof channel param is not string', function() {
+              expect(function() {
+                mediator.emit({});
+              }).toThrow(new Error('Event must be a string or an array'));
+            });
+          });
 
-      it('should allow subscribing multiple callbacks for single event channel', function() {
-        var callback1 = function() {};
-        var callback2 = function() {};
+          it('should call every callback for a channel, within the correct context', function() {
+            var callback = sinon.spy();
 
-        mediator.on(TEST_CHANNEL, 'spec', callback1, this);
-        mediator.on(TEST_CHANNEL, 'spec', callback2, this);
+            var pubsub = mediator.getPubSub(SANDBOX_NAME);
+            pubsub.on(TEST_EVENT, callback);
 
-        //expect(channels[TEST_CHANNEL]).toContain(callback1, callback2);
-        expect(channels[TEST_CHANNEL].length).toBe(2);
-      });
-    });
+            mediator.emit(TEST_EVENT);
 
-    describe('emit', function() {
+            expect(callback).toHaveBeenCalled();
+          });
 
-      describe('verification of parameters', function() {
-        it('should throw an error if all the params are not specified', function () {
-          expect(function () {
-            mediator.emit();
-          }).toThrow(new Error('Channel must be defined'));
-        });
+          it('should pass additional arguments to every call callback for a channel', function() {
+            var callback = sinon.spy();
+            var argument = {};
 
-        it('should throw an error if typeof channel param is not string', function () {
-          expect(function () {
-            mediator.emit({});
-          }).toThrow(new Error('Channel must be a string'));
-        });
-      });
+            var pubsub = mediator.getPubSub(SANDBOX_NAME);
+            pubsub.on(TEST_EVENT, callback);
 
-      it('should call every callback for a channel, within the correct context', function () {
-        var callback = sinon.spy();
+            mediator.emit(TEST_EVENT, argument);
 
-        channels[TEST_CHANNEL] = [
-          {callback:callback}
-        ];
+            expect(callback).toHaveBeenCalledWith(argument);
+          });
 
-        mediator.emit(TEST_CHANNEL);
+          /* 
+   * this could only be implemented at sandbox level pubsub. mediator.emit
+   * is global and broadcasts to all pubsubs
+   *
+  it('should return false if channel has not been defined', function() {
+    var called = mediator.emit(TEST_EVENT);
 
-        expect(callback).toHaveBeenCalled();
-      });
-
-      it('should pass additional arguments to every call callback for a channel', function () {
-        var callback = sinon.spy();
-        var argument = {};
-
-        channels[TEST_CHANNEL] = [
-          {callback:callback}
-        ];
-
-        mediator.emit(TEST_CHANNEL, argument);
-
-        expect(callback).toHaveBeenCalledWith(argument);
-      });
-
-      it('should return false if channel has not been defined', function () {
-        var called = mediator.emit(TEST_CHANNEL);
-
-        expect(called).toBe(false);
-      });
-
-      it('should add to emit queue if widget is loading', function() {
-        channels[TEST_CHANNEL] = [
-          {callback:function() {}}
-        ];
-
-        mediator.start({ channel:TEST_CHANNEL, options: { element: '#nothing' } });
-
-        mediator.emit(TEST_CHANNEL);
-
-        expect(mediator.getEmitQueueLength()).toBe(1);
-      });
-    });
-
-    xdescribe('start', function() {
-      it('should throw an error if all the params are not specified', function () {});
-      it('should throw an error if all the params are not the correct type', function () {});
-      it('should load (require) a widget that corresponds with a channel', function () {});
-      it('should call every callback for the channel, within the correct context', function () {});
-      it('should trigger a requirejs error if the widget does not exist', function (){});
-    });
-
-    xdescribe('stop', function() {
-      it('should throw an error if all the params are not specified', function () {});
-      it('should throw an error if all the params are not the correct type', function () {});
-      it('should call unload with the correct widget to unload from the app', function () {});
-      it('should empty the contents of a specific widget\'s container div', function () {});
-    });
-
-    // This one will need to be researched a little more to determine exactly what require does
-    xdescribe('unload', function () {
-      it('should throw an error if all the params are not specified', function () {});
-      it('should throw an error if all the params are not the correct type', function () {});
-      it('should unload a module and all modules under its widget path', function () {});
-    });
+    expect(called).toBe(false);
   });
-});
+   */
+
+          it('should add to emit queue if widget is loading', function() {
+            var pubsub = mediator.pubsubs[SANDBOX_NAME];
+            pubsub.on(TEST_EVENT, function() {});
+
+            mediator.start({
+              channel: SANDBOX_NAME,
+              options: {
+                element: '#nothing'
+              }
+            });
+
+            mediator.emit(TEST_EVENT);
+
+            expect(mediator.getEmitQueueLength()).toBe(1);
+          });
+        });
+
+        xdescribe('start', function() {
+          it('should throw an error if all the params are not specified', function() {});
+          it('should throw an error if all the params are not the correct type', function() {});
+          it('should load (require) a widget that corresponds with a channel', function() {});
+          it('should call every callback for the channel, within the correct context', function() {});
+          it('should trigger a requirejs error if the widget does not exist', function() {});
+        });
+
+        xdescribe('stop', function() {
+          it('should throw an error if all the params are not specified', function() {});
+          it('should throw an error if all the params are not the correct type', function() {});
+          it('should call unload with the correct widget to unload from the app', function() {});
+          it('should empty the contents of a specific widget\'s container div', function() {});
+        });
+
+        // This one will need to be researched a little more to determine exactly what require does
+        xdescribe('unload', function() {
+          it('should throw an error if all the params are not specified', function() {});
+          it('should throw an error if all the params are not the correct type', function() {});
+          it('should unload a module and all modules under its widget path', function() {});
+        });
+      });
+    });

--- a/src/apps/demo/js/app.js
+++ b/src/apps/demo/js/app.js
@@ -9,7 +9,7 @@ if (typeof Object.create !== 'function') {
 
 // Starts main modules
 // Publishing from core because that's the way that Nicholas did it...
-define(['aura_core', 'backboneSandbox'], function(core, backboneSandbox) {
+define(['aura_core', 'perms', 'backboneSandbox'], function(core, permissions, backboneSandbox) {
   'use strict';
 
   core.getSandbox = function (sandbox) {

--- a/src/apps/demo/js/permissions.js
+++ b/src/apps/demo/js/permissions.js
@@ -5,25 +5,17 @@ define(['aura_perms'], function(permissions) {
 
   permissions.extend({
     todos: {
-      bootstrap: true,
-      'new-event': true,
-      'set-language': true,
-      '*': true
+      emit: ['bootstrap.todos', 'new-event', 'set-language'],
+      on: ['bootstrap.todos', 'new-event', 'set-language']
     },
     calendar: {
-      bootstrap: true,
-      '*': true
+      on: ['bootstrap.calendar', 'route.calendar.**'],
+      emit: ['bootstrap.calendar']
     },
-    controls: {
-      bootstrap: true,
-      '*': true
-    },
+    controls: ['*'], // if emit and on is the same, just enter an array
     router: {
-      bootstrap: true,
-      router: true,
-      calendar: true,
-      todos: true,
-      '*': true
+      emit: ['bootstrap.router', 'calendar.*', 'todos.*', '*', 'route.**'],
+      on: ['bootstrap.router', 'calendar.*', 'todos.*', '*', 'route.**']
     }
   });
 

--- a/src/aura/core.js
+++ b/src/aura/core.js
@@ -9,16 +9,17 @@
 // * [Nicholas Zakas: Scalable JavaScript Application Architecture](http://www.youtube.com/watch?v=vXjVFPosQHw&feature=youtube_gdata_player)
 // * [Writing Modular JavaScript: New Premium Tutorial](http://net.tutsplus.com/tutorials/javascript-ajax/writing-modular-javascript-new-premium-tutorial/)
 // include 'deferred' if using zepto
-define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, permissions) {
+define(['aura_base', 'aura_sandbox', 'aura_perms', 'eventemitter'], function(base, sandbox, permissions, EventEmitter) {
 
   'use strict';
 
   var core = {}; // Mediator object
-  var channels = {}; // Loaded modules and their callbacks
+  var pubsubs = {}; // Pubsub sessions for sandboxes
   var emitQueue = [];
   var isWidgetLoading = false;
   var WIDGETS_PATH = 'widgets'; // Path to widgets
   var sandboxSerial = 0; // For unique widget sandbox module names
+
 
   // Load in the base library, such as Zepto or jQuery. the following are
   // required for Aura to run:
@@ -55,6 +56,16 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
 
   }());
 
+
+  // http://stackoverflow.com/q/11536177 
+  EventEmitter.prototype.emitArgs = function(event, args) {
+    this.emit.apply(this, [event].concat(args));
+  };
+
+  // Attached pubsubs to core
+  core.pubsubs = pubsubs;
+
+
   // The bind method is used for callbacks.
   //
   // * (bind)[https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Function/bind]
@@ -70,8 +81,7 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
       var fToBind = this;
       var FNOP = function() {};
       var FBound = function() {
-          return fToBind.apply(this instanceof FNOP && oThis ? this : oThis,
-          aArgs.concat(Array.prototype.slice.call(arguments)));
+          return fToBind.apply(this instanceof FNOP && oThis ? this : oThis, aArgs.concat(Array.prototype.slice.call(arguments)));
         };
 
       FNOP.prototype = this.prototype;
@@ -116,93 +126,185 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
 
   // Subscribe to an event
   //
-  // * **param:** {string} channel Event name
+  // A facade to sandboxes' pubsub
+  //
+  // * **param:** {string} event Event name
   // * **param:** {string} subscriber Subscriber name
   // * **param:** {function} callback Module callback
   // * **param:** {object} context Context in which to execute the callback
-  core.on = function(channel, subscriber, callback, context) {
-    if (channel === undefined || callback === undefined || context === undefined) {
-      throw new Error('Channel, callback, and context must be defined');
+  core.on = function(event, subscriber, callback, context) {
+    if (event === undefined || subscriber === undefined || callback === undefined || context === undefined) {
+      throw new Error('Event, subscriber, callback, and context must be defined');
     }
-    if (typeof channel !== 'string') {
-      throw new Error('Channel must be a string');
+    if (typeof event !== 'string' || Array.isArray(event)) {
+      throw new Error('Event must be a string or array');
     }
     if (typeof subscriber !== 'string') {
-      throw new Error('Subscriber must be a string');
+      throw new Error('The widget sandbox name must be passed as string');
     }
     if (typeof callback !== 'function') {
       throw new Error('Callback must be a function');
     }
 
-    // Prevent subscription if no permission
-    if (!permissions.validate(channel, subscriber)) {
+    // Prevent subscription to event if subscriber lacks permission
+    if (!core.hasPermission('on', subscriber, event)) {
       return;
+    } else {
+      var pubsub = core.getPubSub(subscriber);
+
+      if (event === "*") { // '*' with no namespace to .onAny
+        pubsub.onAny(callback.bind(context));
+      } else {
+        pubsub.on(event, callback.bind(context));
+      }
+
+    }
+  };
+
+  // Retrieve permissions for a widget sandbox
+  //
+  // * **param:** {string} subscriber sandbox Module name
+  core.getPermissions = function(subscriber) {
+    var sandboxPerms = permissions.rules(subscriber);
+
+    // If permissions entered as a single array, events
+    // will allow both 'on' and 'emit'.
+    if (Array.isArray(sandboxPerms)) {
+      sandboxPerms = {
+        on: sandboxPerms,
+        emit: sandboxPerms
+      };
     }
 
-    channels[channel] = (!channels[channel]) ? [] : channels[channel];
+    return sandboxPerms;
+  };
 
-    if(channel === '*'){
-      for (var key in channels) {
-        if (channels.hasOwnProperty(key)) {
-            channels[key].push({
-               subscriber: subscriber,
-               callback: callback.bind(context)
-            });
+  // Load the permissions for a widget sandbox into the
+  // sandbox's pubsub.
+  //
+  // * **param:** {string} subscriber sandbox Module name
+  core.loadPermissions = function(subscriber) {
+    var pubsub = core.getPubSub(subscriber);
+    var sandboxPerms = core.getPermissions(subscriber);
+    var noopFunction = function() {};
+    var rules, rule, i;
+
+    for (var action in sandboxPerms) {
+      rules = [];
+      rules = sandboxPerms[action];
+      for (i = 0; i < rules.length; i++) {
+        rule = rules[i];
+        rule = typeof rule === 'string' ? rule.split('.') : rule.slice();
+        rule.unshift(action);
+        rule.unshift('perm');
+
+        try {
+          pubsub.on(rule, noopFunction);
+        } catch (e) {
+          console.error(e.message);
         }
       }
-    }else{
-      channels[channel].push({
-        subscriber: subscriber,
-        callback: callback.bind(context)
-        // callback: this.util.method(callback, context)
-      });
+    }
+  };
+
+  // Verify if a module has permission to subscribe to an event.
+  //
+  // Compatible with EventEmitter2 events. Defaults to '.' delimeter.
+  //
+  // * **param:** {string} action 'emit' or 'on'
+  // * **param:** {string} subscriber Module name
+  // * **param:** {string / array} event Event name in EventEmitter2 format
+  core.hasPermission = function(action, subscriber, event) {
+    var pubsub = core.getPubSub(subscriber);
+
+    // Turn 'namespace.ext.that' => ['namespace', 'ext', 'that']
+    var eventPerm = typeof event === 'string' ? event.split('.') : event.slice();
+
+    // Use the 'perm' . 'on' / 'emit' namespace inside of the sandboxes pubsub to determine
+    // permissions. ['perm']['on'] and ['perm']['emit'] ns is a facade for EventEmitter's behavior
+    // to work with permissions
+    //
+    // If permissions allows namespace.ext.that to use listen via 'on',
+    // ['calendar', 'date', 'today'] into ['perm', 'on', 'calendar', 'date', 'today']
+    //
+    eventPerm.unshift(action); // 'emit' or 'on'
+    eventPerm.unshift('perm'); // 'perm' namespace
+
+    try {
+      // if event is catch-all permission, allow anything
+      if (pubsub.listenerTree['perm'][action]['*']) {
+        return true;
+      }
+    } catch (e) {}
+
+    // If event fits pattern, return true
+    return (pubsub.listeners(eventPerm).length > 0) ? true : false;
+  };
+
+  // Return an EventEmitter instance for the sandbox
+  //
+  // Compatible with EventEmitter2 events. Defaults to '.' delimeter.
+  //
+  // * **param:** {string} subscriber Module name
+  core.getPubSub = function(subscriber) {
+    // If PubSub doesn't exist, create
+    if (!core.pubsubs[subscriber]) {
+      core.pubsubs[subscriber] = core.createPubSub(subscriber);
     }
 
+    return core.pubsubs[subscriber];
+  };
+
+  // Create EventEmitter instance
+  core.createPubSub = function() {
+    var pubsub = new EventEmitter({
+      wildcard: true,
+      delimeter: '.'
+    });
+
+    return pubsub;
+  };
+
+  // Remove EventEmitter instance
+  core.removePubSub = function(sandboxName) {
+    pubsubs[sandboxName].removeAllListeners();
+    pubsubs[sandboxName] = null;
+    delete pubsubs[sandboxName];
   };
 
   core.getEmitQueueLength = function() {
     return emitQueue.length;
   };
 
-  // Publish an event, passing arguments to subscribers. Will
-  // call start if the channel is not already registered.
+  // Publish event to all sandbox pubsubs. Supports queued events.
   //
-  // * **param:** {string} channel Event name
-  core.emit = function(channel) {
-    if (channel === undefined) {
-      throw new Error('Channel must be defined');
-    }
-    if (typeof channel !== 'string') {
-      throw new Error('Channel must be a string');
-    }
+  // * **param:** {string} event Event
+  core.emit = function() {
+
     if (isWidgetLoading) { // Catch emit event!
       emitQueue.push(arguments);
       return false;
-    }
+    } else {
+      var event = arguments[0];
+      if (typeof event === 'undefined') {
+        throw new Error('Event must be defined');
+      }
+      if ((typeof event !== 'string') && (!Array.isArray(event))) {
+        throw new Error('Event must be a string or an array');
+      }
+      event = typeof event === 'string' ? event.split('.') : event.slice();
 
-    var i, l;
-    var args = [].slice.call(arguments, 1);
-    if (!channels[channel]) {
-      return false;
-    }
-    for (i = 0; i < channels[channel].length; i++) {
+      var args = [].slice.call(arguments, 1);
+      args = arguments[1];
 
-      // if the callback has been nulled by core.stop, remove this subscriber
-      if (channels[channel][i].callback == null) {
-        channels[channel].splice(i, 1);
-
-        // since we are removing the subscriber at this index, set the iterator
-        // back, so we try this index again
-        i--;
-
-      // otherwise proceed normally: try the callback and iterate
-      } else {
+      for (var key in pubsubs) {
         try {
-          channels[channel][i].callback.apply(this, args);
-        }
-        catch (e) {
+          var pubsub = pubsubs[key];
+          pubsub.emitArgs(event, args);
+        } catch (e) {
           console.error(e.message);
         }
+
       }
     }
 
@@ -226,18 +328,18 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
   };
 
   // Automatically load a widget and initialize it. File name of the
-  // widget will be derived from the channel, decamelized and underscore
-  // delimited by default.
+  // widget will be derived from the sandbox name, decamelized and
+  // underscore delimited by default.
   //
   // * **param:** {Object/Array} an array with objects or single object containing channel and options
   core.start = function(list) {
     var args = [].slice.call(arguments, 1);
 
-    // Allow pair channel & options as params
+    // Allow pair sandboxName & options as params
     if (typeof list === 'string' && args[0] !== undefined) {
       list = [{
-        channel : list,
-        options : args[0]
+        sandboxName: list,
+        options: args[0]
       }];
     }
 
@@ -247,15 +349,15 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
     }
 
     if (!Array.isArray(list)) {
-      throw new Error('Channel must be defined as an array');
+      throw new Error('Sandbox properties must be defined as an array');
     }
 
     var i = 0;
     var l = list.length;
     var promises = [];
 
-    function load(channel, options) {
-      var file = decamelize(channel);
+    function load(sandboxName, options) {
+      var file = decamelize(sandboxName);
       var dfd = core.data.deferred();
       var widgetsPath = core.getWidgetsPath();
       var requireConfig = require.s.contexts._.config;
@@ -280,11 +382,17 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
       });
 
       // Instantiate unique sandbox
-      var widgetSandbox = sandbox.create(core, channel);
+      var widgetSandbox = sandbox.create(core, sandboxName);
+
+      // Create pubsub
+      core.getPubSub(sandboxName);
+
+      // Load permissions into pubsub
+      core.loadPermissions(sandboxName);
 
       // Apply application extensions
       if (core.getSandbox) {
-        widgetSandbox = core.getSandbox(widgetSandbox, channel);
+        widgetSandbox = core.getSandbox(widgetSandbox, sandboxName);
       }
 
       // Define the unique sandbox
@@ -328,31 +436,19 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
   // to the channel/widget. This will both locate and reset the internal
   // state of the modules in require.js and empty the widgets DOM element
   //
-  // * **param:** {string} channel Event name
+  // * **param:** {string} sandboxName Sandbox name
   // * **param:** {string} el Element name (Optional)
-  core.stop = function(channel, el) {
-    var file = decamelize(channel);
+  core.stop = function(sandboxName, el) {
+    var file = decamelize(sandboxName);
 
-    for (var ch in channels) {
-      if (channels.hasOwnProperty(ch)) {
-        for (var i = 0, l = channels[ch].length; i < l; i++) {
-          if (channels[ch][i].subscriber === channel) {
+    core.removePubSub(sandboxName);
 
-            // If core.stop is being called as a callback to core.emit,
-            // removing the subscriber at this point can cause an error with
-            // emit's iterator going longer than the changed array length.
-            // Set the callback to null and have core.emit check this.
-            channels[ch][i].callback = null;
-          }
-        }
-      }
-    }
     // Remove all modules under a widget path (e.g widgets/todos)
     core.unload('widgets/' + file);
 
     // Remove widget descendents, unbinding any event handlers
     // attached to children within the widget.
-    if(el) {
+    if (el) {
       core.dom.find(el).children().remove();
     }
   };
@@ -384,10 +480,6 @@ define(['aura_base', 'aura_sandbox', 'aura_perms'], function(base, sandbox, perm
         require.undef(key);
       }
     }
-  };
-
-  core.getChannels = function() {
-    return channels;
   };
 
   return core;

--- a/src/aura/lib/eventemitter2.js
+++ b/src/aura/lib/eventemitter2.js
@@ -1,0 +1,560 @@
+;!function(exports, undefined) {
+
+  var isArray = Array.isArray ? Array.isArray : function _isArray(obj) {
+    return Object.prototype.toString.call(obj) === "[object Array]";
+  };
+  var defaultMaxListeners = 10;
+
+  function init() {
+    this._events = {};
+    if (this._conf) {
+      configure.call(this, this._conf);
+    }
+  }
+
+  function configure(conf) {
+    if (conf) {
+      
+      this._conf = conf;
+      
+      conf.delimiter && (this.delimiter = conf.delimiter);
+      conf.maxListeners && (this._events.maxListeners = conf.maxListeners);
+      conf.wildcard && (this.wildcard = conf.wildcard);
+      conf.newListener && (this.newListener = conf.newListener);
+
+      if (this.wildcard) {
+        this.listenerTree = {};
+      }
+    }
+  }
+
+  function EventEmitter(conf) {
+    this._events = {};
+    this.newListener = false;
+    configure.call(this, conf);
+  }
+
+  //
+  // Attention, function return type now is array, always !
+  // It has zero elements if no any matches found and one or more
+  // elements (leafs) if there are matches
+  //
+  function searchListenerTree(handlers, type, tree, i) {
+    if (!tree) {
+      return [];
+    }
+    var listeners=[], leaf, len, branch, xTree, xxTree, isolatedBranch, endReached,
+        typeLength = type.length, currentType = type[i], nextType = type[i+1];
+    if (i === typeLength && tree._listeners) {
+      //
+      // If at the end of the event(s) list and the tree has listeners
+      // invoke those listeners.
+      //
+      if (typeof tree._listeners === 'function') {
+        handlers && handlers.push(tree._listeners);
+        return [tree];
+      } else {
+        for (leaf = 0, len = tree._listeners.length; leaf < len; leaf++) {
+          handlers && handlers.push(tree._listeners[leaf]);
+        }
+        return [tree];
+      }
+    }
+
+    if ((currentType === '*' || currentType === '**') || tree[currentType]) {
+      //
+      // If the event emitted is '*' at this part
+      // or there is a concrete match at this patch
+      //
+      if (currentType === '*') {
+        for (branch in tree) {
+          if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
+            listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i+1));
+          }
+        }
+        return listeners;
+      } else if(currentType === '**') {
+        endReached = (i+1 === typeLength || (i+2 === typeLength && nextType === '*'));
+        if(endReached && tree._listeners) {
+          // The next element has a _listeners, add it to the handlers.
+          listeners = listeners.concat(searchListenerTree(handlers, type, tree, typeLength));
+        }
+
+        for (branch in tree) {
+          if (branch !== '_listeners' && tree.hasOwnProperty(branch)) {
+            if(branch === '*' || branch === '**') {
+              if(tree[branch]._listeners && !endReached) {
+                listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], typeLength));
+              }
+              listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i));
+            } else if(branch === nextType) {
+              listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i+2));
+            } else {
+              // No match on this one, shift into the tree but not in the type array.
+              listeners = listeners.concat(searchListenerTree(handlers, type, tree[branch], i));
+            }
+          }
+        }
+        return listeners;
+      }
+
+      listeners = listeners.concat(searchListenerTree(handlers, type, tree[currentType], i+1));
+    }
+
+    xTree = tree['*'];
+    if (xTree) {
+      //
+      // If the listener tree will allow any match for this part,
+      // then recursively explore all branches of the tree
+      //
+      searchListenerTree(handlers, type, xTree, i+1);
+    }
+    
+    xxTree = tree['**'];
+    if(xxTree) {
+      if(i < typeLength) {
+        if(xxTree._listeners) {
+          // If we have a listener on a '**', it will catch all, so add its handler.
+          searchListenerTree(handlers, type, xxTree, typeLength);
+        }
+        
+        // Build arrays of matching next branches and others.
+        for(branch in xxTree) {
+          if(branch !== '_listeners' && xxTree.hasOwnProperty(branch)) {
+            if(branch === nextType) {
+              // We know the next element will match, so jump twice.
+              searchListenerTree(handlers, type, xxTree[branch], i+2);
+            } else if(branch === currentType) {
+              // Current node matches, move into the tree.
+              searchListenerTree(handlers, type, xxTree[branch], i+1);
+            } else {
+              isolatedBranch = {};
+              isolatedBranch[branch] = xxTree[branch];
+              searchListenerTree(handlers, type, { '**': isolatedBranch }, i+1);
+            }
+          }
+        }
+      } else if(xxTree._listeners) {
+        // We have reached the end and still on a '**'
+        searchListenerTree(handlers, type, xxTree, typeLength);
+      } else if(xxTree['*'] && xxTree['*']._listeners) {
+        searchListenerTree(handlers, type, xxTree['*'], typeLength);
+      }
+    }
+
+    return listeners;
+  }
+
+  function growListenerTree(type, listener) {
+
+    type = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+    
+    //
+    // Looks for two consecutive '**', if so, don't add the event at all.
+    //
+    for(var i = 0, len = type.length; i+1 < len; i++) {
+      if(type[i] === '**' && type[i+1] === '**') {
+        return;
+      }
+    }
+
+    var tree = this.listenerTree;
+    var name = type.shift();
+
+    while (name) {
+
+      if (!tree[name]) {
+        tree[name] = {};
+      }
+
+      tree = tree[name];
+
+      if (type.length === 0) {
+
+        if (!tree._listeners) {
+          tree._listeners = listener;
+        }
+        else if(typeof tree._listeners === 'function') {
+          tree._listeners = [tree._listeners, listener];
+        }
+        else if (isArray(tree._listeners)) {
+
+          tree._listeners.push(listener);
+
+          if (!tree._listeners.warned) {
+
+            var m = defaultMaxListeners;
+            
+            if (typeof this._events.maxListeners !== 'undefined') {
+              m = this._events.maxListeners;
+            }
+
+            if (m > 0 && tree._listeners.length > m) {
+
+              tree._listeners.warned = true;
+              console.error('(node) warning: possible EventEmitter memory ' +
+                            'leak detected. %d listeners added. ' +
+                            'Use emitter.setMaxListeners() to increase limit.',
+                            tree._listeners.length);
+              console.trace();
+            }
+          }
+        }
+        return true;
+      }
+      name = type.shift();
+    }
+    return true;
+  };
+
+  // By default EventEmitters will print a warning if more than
+  // 10 listeners are added to it. This is a useful default which
+  // helps finding memory leaks.
+  //
+  // Obviously not all Emitters should be limited to 10. This function allows
+  // that to be increased. Set to zero for unlimited.
+
+  EventEmitter.prototype.delimiter = '.';
+
+  EventEmitter.prototype.setMaxListeners = function(n) {
+    this._events || init.call(this);
+    this._events.maxListeners = n;
+    if (!this._conf) this._conf = {};
+    this._conf.maxListeners = n;
+  };
+
+  EventEmitter.prototype.event = '';
+
+  EventEmitter.prototype.once = function(event, fn) {
+    this.many(event, 1, fn);
+    return this;
+  };
+
+  EventEmitter.prototype.many = function(event, ttl, fn) {
+    var self = this;
+
+    if (typeof fn !== 'function') {
+      throw new Error('many only accepts instances of Function');
+    }
+
+    function listener() {
+      if (--ttl === 0) {
+        self.off(event, listener);
+      }
+      fn.apply(this, arguments);
+    };
+
+    listener._origin = fn;
+
+    this.on(event, listener);
+
+    return self;
+  };
+
+  EventEmitter.prototype.emit = function() {
+    
+    this._events || init.call(this);
+
+    var type = arguments[0];
+
+    if (type === 'newListener' && !this.newListener) {
+      if (!this._events.newListener) { return false; }
+    }
+
+    // Loop through the *_all* functions and invoke them.
+    if (this._all) {
+      var l = arguments.length;
+      var args = new Array(l - 1);
+      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+      for (i = 0, l = this._all.length; i < l; i++) {
+        this.event = type;
+        this._all[i].apply(this, args);
+      }
+    }
+
+    // If there is no 'error' event listener then throw.
+    if (type === 'error') {
+      
+      if (!this._all && 
+        !this._events.error && 
+        !(this.wildcard && this.listenerTree.error)) {
+
+        if (arguments[1] instanceof Error) {
+          throw arguments[1]; // Unhandled 'error' event
+        } else {
+          throw new Error("Uncaught, unspecified 'error' event.");
+        }
+        return false;
+      }
+    }
+
+    var handler;
+
+    if(this.wildcard) {
+      handler = [];
+      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+      searchListenerTree.call(this, handler, ns, this.listenerTree, 0);
+    }
+    else {
+      handler = this._events[type];
+    }
+
+    if (typeof handler === 'function') {
+      this.event = type;
+      if (arguments.length === 1) {
+        handler.call(this);
+      }
+      else if (arguments.length > 1)
+        switch (arguments.length) {
+          case 2:
+            handler.call(this, arguments[1]);
+            break;
+          case 3:
+            handler.call(this, arguments[1], arguments[2]);
+            break;
+          // slower
+          default:
+            var l = arguments.length;
+            var args = new Array(l - 1);
+            for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+            handler.apply(this, args);
+        }
+      return true;
+    }
+    else if (handler) {
+      var l = arguments.length;
+      var args = new Array(l - 1);
+      for (var i = 1; i < l; i++) args[i - 1] = arguments[i];
+
+      var listeners = handler.slice();
+      for (var i = 0, l = listeners.length; i < l; i++) {
+        this.event = type;
+        listeners[i].apply(this, args);
+      }
+      return (listeners.length > 0) || this._all;
+    }
+    else {
+      return this._all;
+    }
+
+  };
+
+  EventEmitter.prototype.on = function(type, listener) {
+    
+    if (typeof type === 'function') {
+      this.onAny(type);
+      return this;
+    }
+
+    if (typeof listener !== 'function') {
+      throw new Error('on only accepts instances of Function');
+    }
+    this._events || init.call(this);
+
+    // To avoid recursion in the case that type == "newListeners"! Before
+    // adding it to the listeners, first emit "newListeners".
+    this.emit('newListener', type, listener);
+
+    if(this.wildcard) {
+      growListenerTree.call(this, type, listener);
+      return this;
+    }
+
+    if (!this._events[type]) {
+      // Optimize the case of one listener. Don't need the extra array object.
+      this._events[type] = listener;
+    }
+    else if(typeof this._events[type] === 'function') {
+      // Adding the second element, need to change to array.
+      this._events[type] = [this._events[type], listener];
+    }
+    else if (isArray(this._events[type])) {
+      // If we've already got an array, just append.
+      this._events[type].push(listener);
+
+      // Check for listener leak
+      if (!this._events[type].warned) {
+
+        var m = defaultMaxListeners;
+        
+        if (typeof this._events.maxListeners !== 'undefined') {
+          m = this._events.maxListeners;
+        }
+
+        if (m > 0 && this._events[type].length > m) {
+
+          this._events[type].warned = true;
+          console.error('(node) warning: possible EventEmitter memory ' +
+                        'leak detected. %d listeners added. ' +
+                        'Use emitter.setMaxListeners() to increase limit.',
+                        this._events[type].length);
+          console.trace();
+        }
+      }
+    }
+    return this;
+  };
+
+  EventEmitter.prototype.onAny = function(fn) {
+
+    if(!this._all) {
+      this._all = [];
+    }
+
+    if (typeof fn !== 'function') {
+      throw new Error('onAny only accepts instances of Function');
+    }
+
+    // Add the function to the event listener collection.
+    this._all.push(fn);
+    return this;
+  };
+
+  EventEmitter.prototype.addListener = EventEmitter.prototype.on;
+
+  EventEmitter.prototype.off = function(type, listener) {
+    if (typeof listener !== 'function') {
+      throw new Error('removeListener only takes instances of Function');
+    }
+
+    var handlers,leafs=[];
+
+    if(this.wildcard) {
+      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+      leafs = searchListenerTree.call(this, null, ns, this.listenerTree, 0);
+    }
+    else {
+      // does not use listeners(), so no side effect of creating _events[type]
+      if (!this._events[type]) return this;
+      handlers = this._events[type];
+      leafs.push({_listeners:handlers});
+    }
+
+    for (var iLeaf=0; iLeaf<leafs.length; iLeaf++) {
+      var leaf = leafs[iLeaf];
+      handlers = leaf._listeners;
+      if (isArray(handlers)) {
+
+        var position = -1;
+
+        for (var i = 0, length = handlers.length; i < length; i++) {
+          if (handlers[i] === listener ||
+            (handlers[i].listener && handlers[i].listener === listener) ||
+            (handlers[i]._origin && handlers[i]._origin === listener)) {
+            position = i;
+            break;
+          }
+        }
+
+        if (position < 0) {
+          return this;
+        }
+
+        if(this.wildcard) {
+          leaf._listeners.splice(position, 1)
+        }
+        else {
+          this._events[type].splice(position, 1);
+        }
+
+        if (handlers.length === 0) {
+          if(this.wildcard) {
+            delete leaf._listeners;
+          }
+          else {
+            delete this._events[type];
+          }
+        }
+      }
+      else if (handlers === listener ||
+        (handlers.listener && handlers.listener === listener) ||
+        (handlers._origin && handlers._origin === listener)) {
+        if(this.wildcard) {
+          delete leaf._listeners;
+        }
+        else {
+          delete this._events[type];
+        }
+      }
+    }
+
+    return this;
+  };
+
+  EventEmitter.prototype.offAny = function(fn) {
+    var i = 0, l = 0, fns;
+    if (fn && this._all && this._all.length > 0) {
+      fns = this._all;
+      for(i = 0, l = fns.length; i < l; i++) {
+        if(fn === fns[i]) {
+          fns.splice(i, 1);
+          return this;
+        }
+      }
+    } else {
+      this._all = [];
+    }
+    return this;
+  };
+
+  EventEmitter.prototype.removeListener = EventEmitter.prototype.off;
+
+  EventEmitter.prototype.removeAllListeners = function(type) {
+    if (arguments.length === 0) {
+      !this._events || init.call(this);
+      return this;
+    }
+
+    if(this.wildcard) {
+      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+      var leafs = searchListenerTree.call(this, null, ns, this.listenerTree, 0);
+
+      for (var iLeaf=0; iLeaf<leafs.length; iLeaf++) {
+        var leaf = leafs[iLeaf];
+        leaf._listeners = null;
+      }
+    }
+    else {
+      if (!this._events[type]) return this;
+      this._events[type] = null;
+    }
+    return this;
+  };
+
+  EventEmitter.prototype.listeners = function(type) {
+    if(this.wildcard) {
+      var handlers = [];
+      var ns = typeof type === 'string' ? type.split(this.delimiter) : type.slice();
+      searchListenerTree.call(this, handlers, ns, this.listenerTree, 0);
+      return handlers;
+    }
+
+    this._events || init.call(this);
+
+    if (!this._events[type]) this._events[type] = [];
+    if (!isArray(this._events[type])) {
+      this._events[type] = [this._events[type]];
+    }
+    return this._events[type];
+  };
+
+  EventEmitter.prototype.listenersAny = function() {
+
+    if(this._all) {
+      return this._all;
+    }
+    else {
+      return [];
+    }
+
+  };
+
+  if (typeof define === 'function' && define.amd) {
+    define(function() {
+      return EventEmitter;
+    });
+  } else {
+    exports.EventEmitter2 = EventEmitter; 
+  }
+
+}(typeof process !== 'undefined' && typeof process.title !== 'undefined' && typeof exports !== 'undefined' ? exports : window);

--- a/src/aura/permissions.js
+++ b/src/aura/permissions.js
@@ -4,6 +4,10 @@
 // to clear. This enforces a flexible security
 // layer for your application.
 //
+// This module houses the structure of a module's
+// permission. The logic that validates and builds
+// permissions are in the mediator (core.js).
+//
 // {eventName: {moduleName:[true|false]}, ...}
 define(['dom'], function($) {
   'use strict';
@@ -20,12 +24,8 @@ define(['dom'], function($) {
   };
 
   // * **param:** {string} subscriber Module name
-  // * **param:** {string} channel Event name
-  permissions.validate = function(subscriber, channel) {
-    var channelRules = rules[channel] || {};
-    var test = channelRules[subscriber];
-
-    return test === undefined ? false : test;
+  permissions.rules = function(subscriber) {
+    return rules[subscriber];
   };
 
   return permissions;

--- a/src/aura/sandbox.js
+++ b/src/aura/sandbox.js
@@ -10,19 +10,41 @@ define(function() {
 
       sandbox.log = function() {
         var args = Array.prototype.concat.apply([channel], arguments);
+
         mediator.log.apply(mediator, args);
       };
 
-      // * **param:** {string} channel Event name
-      // * **param:** {object} callback Module
-      // * **param:** {object} context Callback context
-      sandbox.on = function(fromChannel, callback, context) {
-        mediator.on(fromChannel, channel, callback, context || this);
+      sandbox.log.event = function() {
+        sandbox.log('[event2log] Event from: ' + channel);
+        if (arguments.length) {
+          sandbox.log('Additional data:', arguments);
+        }
       };
 
+      // * **param:** {string} event
+      // * **param:** {object} callback Module
+      // * **param:** {object} context Callback context
+      sandbox.on = function(event, callback, context) {
+        mediator.on(event, channel, callback, context || this);
+        //core.on = function(event, subscriber, callback, context) {
+
+      };
+
+      // sandbox.logEvent can subscribe to events and print them
+      //
+      // * **param:** {string} event
+      // * **param:** {object} context Callback context
+      sandbox.on.log = function(event, context) {
+        mediator.on(event, channel, sandbox.log.event, context || this);
+        //core.on = function(event, subscriber, callback, context) {
+
+      };
+
+
       // * **param:** {string} channel Event name
-      sandbox.emit = function(channel) {
+      sandbox.emit = function() {
         mediator.emit.apply(mediator, arguments);
+        //core.emit = function(event) {
       };
 
       // * **param:** {Object/Array} an array with objects or single object containing channel and element

--- a/src/config.js
+++ b/src/config.js
@@ -66,6 +66,9 @@ define(function() {
       // Underscore (Lo-Dash - http://lodash.com)
       underscore: '../../../aura/lib/lodash',
 
+      // EventEmitter
+      eventemitter: '../../../aura/lib/eventemitter2',
+
       // Set the base library
       dom: '../../../aura/lib/dom',
 

--- a/src/extensions/backbone/sandbox.js
+++ b/src/extensions/backbone/sandbox.js
@@ -1,7 +1,7 @@
 // ## Sandbox Extension
 // @fileOverview Extend the aura-sandbox (facade pattern)
 // @todo This is a stupid place to include jquery ui
-define(['perms', 'backbone', 'localstorage', 'jquery_ui'], function(perms, Backbone, Store) {
+define(['backbone', 'localstorage', 'jquery_ui'], function(Backbone, Store) {
   'use strict';
 
   return {

--- a/src/widgets/boilerplate/main.js
+++ b/src/widgets/boilerplate/main.js
@@ -6,15 +6,9 @@ define(['sandbox', './views/app'], function(sandbox, AppView) {
       el: sandbox.dom.find(options.element)
     });
 
-    sandbox.emit('bootstrap', 'boilerplate');
+    sandbox.emit('bootstrap.boilerplate', 'Initialized Boilerplate.');
 
-    sandbox.on('bootstrap', function(from) {
-      sandbox.log('Boilerplate-bootstrap message from: ' + from);
-    });
-
-    sandbox.on('*', function(from){
-      sandbox.log('Wildcard event from:', from);
-    });
+    sandbox.on.log('bootstrap.boilerplate');
 
   };
 

--- a/src/widgets/calendar/main.js
+++ b/src/widgets/calendar/main.js
@@ -11,15 +11,8 @@ define(['sandbox', './views/app', './collections/events', 'fullcalendar'], funct
 
     events.fetch();
 
-
-
-    sandbox.emit('bootstrap', 'calendar');
-    sandbox.emit('*', 'calendar', 'bubblegum');
-    sandbox.on('bootstrap', function(from, data) {
-      sandbox.log('Calendar-bootstrap message from: ' + from);
-      sandbox.log('Additional data:', data);
-      sandbox.emit('*','controls');
-    });
+    sandbox.emit('bootstrap.calendar', 'Initialized Calendar.');
+    sandbox.on.log('bootstrap.calendar');
   };
 
 });

--- a/src/widgets/calendar/views/app.js
+++ b/src/widgets/calendar/views/app.js
@@ -18,11 +18,12 @@ define(['sandbox', './event', '../models/event', 'text!../templates/base.html'],
       this.eventView.collection = this.collection;
 
       // subscribe to routing events
-      sandbox.on('calendar', this.calendarController, this);
+      sandbox.on('route.calendar.**', this.calendarController, this);
     },
 
     calendarController: function() {
-      var args = arguments;
+      var slice = Array.prototype.slice;
+      var args = slice.call(arguments, 1); // strip off 'calendar'
       var action = args[0]; // such as 'changeView'
 
       if (action === 'gotoDate') {

--- a/src/widgets/controls/main.js
+++ b/src/widgets/controls/main.js
@@ -6,14 +6,7 @@ define(['sandbox', './views/app'], function(sandbox, AppView) {
       el: sandbox.dom.find(options.element)
     });
 
-    sandbox.emit('bootstrap', 'controls');
-
-    sandbox.on('bootstrap', function(from) {
-      sandbox.log('Controls-bootstrap message from: ' + from);
-    });
-    sandbox.on('*', function(from){
-      sandbox.log('A wildcard was caught from:', from);
-    });
+    sandbox.emit('bootstrap.controls', 'Initialized Controls.');
 
   };
 

--- a/src/widgets/router/main.js
+++ b/src/widgets/router/main.js
@@ -6,6 +6,8 @@ define(['sandbox', 'underscore'], function(sandbox, _) {
     var Router = sandbox.mvc.Router({
       initialize: function() {
         Backbone.history.start();
+
+        sandbox.emit('bootstrap.router', 'Initialized Router');
       },
       routes: {
         '*router': 'router'
@@ -13,23 +15,21 @@ define(['sandbox', 'underscore'], function(sandbox, _) {
 
       router: function(args) {
         var slice = Array.prototype.slice;
+        var event, route;
         args = args.split('/');
+        event = slice.call(args,0);
+        event.unshift('route');
+        route = event.join('.');
 
-        sandbox.emit.apply(this, Array.prototype.slice.call(args));
+        sandbox.emit(route, args);
       }
 
     });
 
     var router = new Router();
 
-    sandbox.emit('bootstrap', 'router');
-    sandbox.on('bootstrap', function(from) {
-      sandbox.log('Router-bootstrap message from: ' + from);
-    });
-
-    sandbox.on('router', function() {
-      sandbox.log('Route in router widget: ', Array.prototype.slice.call(arguments));
-    });
+    sandbox.on.log('bootstrap.router');
+    sandbox.on.log('route.**');
   };
 
 });

--- a/src/widgets/todos/main.js
+++ b/src/widgets/todos/main.js
@@ -6,10 +6,9 @@ define(['sandbox', './views/app'], function(sandbox, AppView) {
       el: sandbox.dom.find(options.element)
     });
 
-    sandbox.emit('bootstrap', 'todos');
-    sandbox.on('bootstrap', function(from) {
-      sandbox.log('Todos-bootstrap message from: ' + from);
-    });
+    sandbox.emit('bootstrap.todos', 'To Do Initialized.');
+
+    sandbox.on.log('bootstrap.todos');
 
     sandbox.on('set-language', function(lang) {
       sandbox.log('Language set to: ' + lang);


### PR DESCRIPTION
Total overhaul of messaging + permissions in Aura. It's a work in progress. It should work in browser, with the exception of hashChange.
- Pubsub compatible w/ EventEmitter2.
- Permissions compatible w/ EventEmitter2.

Naming and conventions:
- 'subscriber' is the name of the widget sandbox.
- 'channel' is being converted to 'event'.

In the background:
- Sandboxes have their own pubsub in `pubsubs`. Where `pubsubs.calendar` is an EventEmitter instance for the `calendar` sandbox widget.
- Garbage collection: Upon a sandbox/widget being destroyed, the pubsub has `removeAllListeners()`, it null'd and then deleted.
- Most of the logic for permissions is inside the mediator / core.js.
- aura/permissions.js currently only holds a structure and accessor.
- Each pubsub reserves `perm.` namespace, which is populated from the sandbox's permission file. `perm` namespace is used  permissions can have full `*` and `**` support.
- '*' without namespace is `.onAny`

If we are ok with this route, I need rewrite our unit tests and clean up things:
- Should permissions whitelist `on`, `emit`, or both?
- Do we want a global config option to disable permissions?
- Do we want give sandbox'd widgets access to listen/broadcast inside themselves?
