### PR TITLE
Fix for fullcalendar bug

### DIFF
--- a/src/extensions/backbone/lib/localstorage.js
+++ b/src/extensions/backbone/lib/localstorage.js
@@ -31,11 +31,11 @@ _.extend(Store.prototype, {
 
   // Add a model, giving it a (hopefully)-unique GUID, if it doesn't already
   // have an id of it's own.
-  create: function(model) {
-    if (!model.id) model.id = model.attributes.id = guid();
-    this.data[model.id] = model;
+  create: function(data, model) {
+    if (!model.id) data[model.idAttribute] = guid(); 
+    this.data[data[model.idAttribute]] = model;
     this.save();
-    return model;
+    return data;
   },
 
   // Update a model by replacing its copy in `this.data`.
@@ -72,10 +72,10 @@ Backbone.sync = function(method, model, options) {
   var store = model.localStorage || model.collection.localStorage;
 
   switch (method) {
-    case "read":    resp = model.id ? store.find(model) : store.findAll(); break;
-    case "create":  resp = store.create(model);                            break;
-    case "update":  resp = store.update(model);                            break;
-    case "delete":  resp = store.destroy(model);                           break;
+    case "read":    resp = model.id ? store.find(model.toJSON()) : store.findAll(); break;
+    case "create":  resp = store.create(model.toJSON(), model);                     break;
+    case "update":  resp = store.update(model.toJSON());                            break;
+    case "delete":  resp = store.destroy(model.toJSON());                           break;
   }
 
   if (resp) {


### PR DESCRIPTION
It seems to me the problem is in the local storage adapter. I haven't been able to find any reference where that comes from, so if this is not the right place for the PR, please let me know where to put it.

In short:

• Don't call the success method with the entire model as argument
(backbone treats this as data returned from the server and SETS the
entire model to itself, creating a weird circular references)

• Don't save the entire backbone model stuff in localstorage, just save
the data.

• Use backbone's own internal mechanism for idAttributes. Not everyone
uses id

These fixes closes #190
