### PR TITLE
Use camel case for data attributes passed to options

### DIFF
--- a/lib/ext/widgets.js
+++ b/lib/ext/widgets.js
@@ -179,10 +179,12 @@ define('aura/ext/widgets', function() {
       var data = core.dom.data(el);
 
       // Here we go through all the data attributes of the element to build the options object
-      core.util.each(data, function(k,v) {
-        var key = core.util.decamelize(k).toLowerCase().replace(new RegExp("^" + namespace +"_"), '');
-        if (key !== 'widget') {
-          options[key] = v;
+      core.util.each(data, function(k, v) {
+        k = k.replace(new RegExp("^" + namespace), "");
+        k = k.charAt(0).toLowerCase() + k.slice(1);
+
+        if (k !== "widget") {
+          options[k] = v;
         } else {
           var ref = v.split("@");
           widgetName    = core.util.decamelize(ref[0]);

--- a/spec/lib/ext/widgets_spec.js
+++ b/spec/lib/ext/widgets_spec.js
@@ -76,17 +76,19 @@ define(['aura/aura', 'aura/ext/widgets'], function(aura, ext) {
 
     describe("Using alternate namespace for data-attributes...", function() {
 
-      var app, options, myAltWidget = makeSpyWidget('alt_namespace', {
+      var app, options;
+
+      var myAltWidget = makeSpyWidget('alt_namespace', {
         initialize: function() {
           options = this.options;
         }
       });
 
-
       before(function(done) {
-        app = aura({ namespace: 'super' });
-        var container = buildAppMarkup('<div data-super-widget="alt_namespace" data-super-genial="yep"></div>');
-        app.start({ widgets: container }).done(function() { 
+        var container = buildAppMarkup("<div data-super-widget='alt_namespace' data-super-param-name='value'></div>");
+
+        app = aura({ namespace: "super" });
+        app.start({ widgets: container }).done(function() {
           setTimeout(done, 0);
         });
       });
@@ -96,7 +98,7 @@ define(['aura/aura', 'aura/ext/widgets'], function(aura, ext) {
       });
 
       it("It should take the right options too...", function() {
-        options.genial.should.equal("yep");
+        options.paramName.should.equal("value");
       });
 
     });


### PR DESCRIPTION
In widgets, options passed by data attributes are snake cased, which is inconsistent with the rest of Aura.

`data-aura-param-name="value"` is translated to `param_name` with this change it will be translated to `paramName`.
