### PR TITLE
Rename extension init method to initialize

### DIFF
--- a/lib/aura.extensions.js
+++ b/lib/aura.extensions.js
@@ -146,16 +146,14 @@ define(['./base'], function(base) {
       // If ext is a function, call it
       // Else If ext has a init method, call it
       try {
-        var init = when(getFn(ext, ext.init)(context));
-
+        var init = when(getFn(ext, ext.initialize)(context));
         init.done(function() { dfd.resolve(ext); });
-
         init.fail(dfd.reject);
       } catch(e) {
         dfd.reject(e);
       }
-
     });
+
     return dfd.promise();
   }
 

--- a/lib/ext/debug.js
+++ b/lib/ext/debug.js
@@ -1,12 +1,12 @@
 define('aura/ext/debug', function() {
 
   'use strict';
-  
+
   return {
 
     name: 'debug',
 
-    init: function(app) {
+    initialize: function(app) {
       // app.initStatus.progress(function(level, msg) {
       //   var logFn = console[level] || console.log || function(){};
       //   var args = [['Init Status']].concat(Array.prototype.slice.call(arguments, 1));

--- a/lib/ext/mediator.js
+++ b/lib/ext/mediator.js
@@ -3,12 +3,11 @@ define('aura/ext/mediator', function() {
   'use strict';
 
   return {
-
     name: 'mediator',
 
     require: { paths: { eventemitter: 'components/eventemitter2/lib/eventemitter2' } },
-  
-    init: function(app) {
+
+    initialize: function(app) {
       var EventEmitter    = require('eventemitter');
       var mediatorConfig  = app.config.mediator || { wildcard: true, delimiter: ".", maxListeners: 20, newListener: true };
       var mediator        = new EventEmitter(mediatorConfig);

--- a/lib/ext/widgets.js
+++ b/lib/ext/widgets.js
@@ -250,13 +250,11 @@ define('aura/ext/widgets', function() {
     };
 
     return {
-
       name: 'widgets',
 
       require: { paths: { text: 'components/requirejs-text/text' } },
-      
 
-      init: function(app) {
+      initialize: function(app) {
 
         // Widgets 'classes' registry...
         app.core.Widgets.Base = Widget;

--- a/spec/lib/aura.extensions_spec.js
+++ b/spec/lib/aura.extensions_spec.js
@@ -61,7 +61,7 @@ define(['aura/aura.extensions'], function(ExtManager) {
       it("Should ensure extensions are loaded sequentially", function(done) {
         var mgr = new ExtManager(),
             ctx = { foo: "Bar" },
-            ext1 = { init: function(c) { 
+            ext1 = { initialize: function(c) {
               var later = $.Deferred();
               _.delay(function() { 
                 c.ext1Loaded = true; 
@@ -79,14 +79,14 @@ define(['aura/aura.extensions'], function(ExtManager) {
 
       it("Should be possible to add an extension via its module ref name", function(done) {
         var mgr = new ExtManager(),
-            ext = { init: sinon.spy(), foo: "bar" },
+            ext = { initialize: sinon.spy(), foo: "bar" },
             ctx = { foo: "bar" };
 
         define("myExt", ext);
         mgr.add({ ref: "myExt", context: ctx });
         mgr.init().done(function(extResolved) {
           extResolved[0].foo.should.equal("bar");
-          ext.init.should.have.been.calledWith(ctx);
+          ext.initialize.should.have.been.calledWith(ctx);
           done();
         });
       });
@@ -101,7 +101,7 @@ define(['aura/aura.extensions'], function(ExtManager) {
       });
 
       it("Should fail init if a dependency is not found", function(done) {
-        var ext = { require: { paths: { not_here: 'not_here' } }, init: sinon.spy() },
+        var ext = { require: { paths: { not_here: 'not_here' } }, initialize: sinon.spy() },
             mgr = new ExtManager();
         mgr.add({ ref: ext });
         mgr.init().fail(function() {
@@ -118,8 +118,8 @@ define(['aura/aura.extensions'], function(ExtManager) {
             ctx       = {},
             ready     = sinon.spy(),
             alsoReady = sinon.spy();
-        define("ext1", { init: function(c) { c.one = true; } });
-        define("ext2", { init: function(c) { c.two = true; } });
+        define("ext1", { initialize: function(c) { c.one = true; } });
+        define("ext2", { initialize: function(c) { c.two = true; } });
         mgr.add({ ref: "ext1", context: ctx });
         mgr.add({ ref: "ext2", context: ctx });
         mgr.onReady(ready);
@@ -132,9 +132,9 @@ define(['aura/aura.extensions'], function(ExtManager) {
         });
       });
 
-      it("Should call onFailure callbacks when init has failed", function(done) {
+      it("Should call onFailure callbacks when initialize has failed", function(done) {
         var onFail = sinon.spy(),
-            mgr    = new ExtManager().add({ ref: { init: function() { throw new Error('FAIL'); }} });
+            mgr    = new ExtManager().add({ ref: { initialize: function() { throw new Error('FAIL'); }} });
         mgr.onFailure(onFail);
         mgr.init().always(function() {
           onFail.should.have.been.called;

--- a/spec/lib/aura_spec.js
+++ b/spec/lib/aura_spec.js
@@ -7,7 +7,7 @@ define(['aura/aura'], function(aura) {
     describe("App Public API", function() {
 
       var ext = {
-        init: sinon.spy(function(app) {
+        initialize: sinon.spy(function(app) {
           app.sandbox.foo = "bar";
         }),
         afterAppStart: sinon.spy()
@@ -38,8 +38,8 @@ define(['aura/aura'], function(aura) {
         App.stop.should.be.a('function');
       });
 
-      it("Should call init method on extension", function() {
-        ext.init.should.have.been.calledWith(App);
+      it("Should call initialize method on extension", function() {
+        ext.initialize.should.have.been.calledWith(App);
       });
 
       it("Should call afterAppStart method on extension", function() {
@@ -59,9 +59,9 @@ define(['aura/aura'], function(aura) {
     describe("Defining and loading extensions", function() {
 
       it("Should be able to use extensions defined as objects", function(done) {
-        var ext = { init: sinon.spy() };
+        var ext = { initialize: sinon.spy() };
         aura().use(ext).start({ widgets: [] }).done(function() {
-          ext.init.should.have.been.called;
+          ext.initialize.should.have.been.called;
           done();
         });
       });
@@ -94,10 +94,10 @@ define(['aura/aura'], function(aura) {
       });
 
       it("Should be able to use extensions defined as amd modules", function(done) {
-        var ext = { init: sinon.spy() };
+        var ext = { initialize: sinon.spy() };
         define("myExtensionModule", ext);
         aura().use("myExtensionModule").start().done(function() {
-          ext.init.should.have.been.called;
+          ext.initialize.should.have.been.called;
           done();
         });
       });

--- a/spec/lib/ext/widgets_spec.js
+++ b/spec/lib/ext/widgets_spec.js
@@ -114,7 +114,7 @@ define(['aura/aura', 'aura/ext/widgets'], function(aura, ext) {
 
       // An extension to load it
       var ext = {
-        init: function(app) {
+        initialize: function(app) {
           app.core.registerWidgetType("NewWidgetType", NewWidgetType);
         }
       };
@@ -192,11 +192,11 @@ define(['aura/aura', 'aura/ext/widgets'], function(aura, ext) {
     describe("Adding new widgets source via an extension", function() {
 
       var anExternalWidget = makeSpyWidget('ext_widget@aSource');
-      
-      var app, ext = { 
-        init: function(app) {
+
+      var app, ext = {
+        initialize: function(app) {
           app.registerWidgetsSource('aSource', 'aUrl');
-        } 
+        }
       };
       before(function(done) {
         var container = buildAppMarkup('<div data-aura-widget="ext_widget@aSource"></div>');


### PR DESCRIPTION
To make API consitent between widgets and extensions, I've renamed extension `init` method to `initialize`.
