### PR TITLE
Fix test script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "grunt-mocha": "~0.2.2"
   },
   "scripts": {
-    "test": "bower install; grunt build"
+    "pretest": "bower install",
+    "test": "grunt build"
   }
 }


### PR DESCRIPTION
`bower install` moved to `pretest` script because `npm` on Windows not worked properly with semicolon separator.
