### PR TITLE
Fix wrong key on README.md example: 'widget' for 'widgets'

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Now that we have our `app`, we can start it.
 
 ```js
 app.start({
-  widget: 'body'
+  widgets: 'body'
 });
 ```
 


### PR DESCRIPTION
The widgets extension looks for the key 'widgets', not for the key 'widget':

``` js
 afterAppStart: function(app) {
        // Auto start widgets when the app is loaded.
        if (app.startOptions.widgets) { // <== RIGHT HERE!
          app.core.start(app.startOptions.widgets);
        }
      }
```

And on readme it says:

``` js
app.start({
  widget: 'body'
});
```

And the correct should be:

``` js
app.start({
  widgets: 'body'
});
```
