### PR TITLE
Make Function.prototype.bind play nice with ie8

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -3,25 +3,13 @@ define(function() {
   //
   // * (bind)[https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Function/bind]
   // * (You don't need to use $.proxy)[http://www.aaron-powell.com/javascript/you-dont-need-jquery-proxy]
+  // * credits: taken from bind_even_never in this discussion: https://prototype.lighthouseapp.com/projects/8886/tickets/215-optimize-bind-bindaseventlistener#ticket-215-9
   if (typeof Function.prototype.bind !== "function") {
-    Function.prototype.bind = function(oThis) {
-      if (typeof this !== "function") {
-        // closest thing possible to the ECMAScript 5 internal IsCallable function
-        throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-      }
-
-      var aArgs = Array.prototype.slice.call(arguments, 1);
-      var fToBind = this;
-      var FNOP = function() {};
-      var FBound = function() {
-          return fToBind.apply(this instanceof FNOP && oThis ? this : oThis,
-          aArgs.concat(Array.prototype.slice.call(arguments)));
-        };
-
-      FNOP.prototype = this.prototype;
-      FBound.prototype = new FNOP();
-
-      return FBound;
+    Function.prototype.bind = function(context) {
+       var fn = this, args = Array.prototype.slice.call(arguments, 1);
+       return function(){
+          return fn.apply(context, Array.prototype.concat.apply(args, arguments));
+       };
     };
   }
 


### PR DESCRIPTION
When I was testing my stuff with IE8 I can into the error:
"Error in IE8: JS5023: Function does not have a valid prototype object"

I did some research an came across this this issue and this post:
https://github.com/Zenovations/console-normalizer/issues/1
https://prototype.lighthouseapp.com/projects/8886/tickets/215-optimize-bind-bindaseventlistener#ticket-215-9

I did not test the speed implications but the error in ie8 is gone and it supposed to be faster - so double win! :)
