### PR TITLE
Fixed closing div tags in gh-pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,16 +179,16 @@ app.start({ widgets: 'body' });
 
 <p>Now we can place this widget everywhere in our app by using Aura's HTML API based on data-attributes.</p>
 
-<pre><code>&lt;div data-aura-widget="issues" data-aura-repo="aurajs/aura"&gt;&lt;/div&gt;
+<pre><code>&lt;div data-aura-widget="issues" data-aura-repo="aurajs/aura"&gt;&lt; &#47;div&gt;
 </code></pre>
 
 <p>You can even have multiple instances of this widget in you page :</p>
 
 <pre><code>&lt;div class='row'&gt;
-  &lt;div class='span4' data-aura-widget="issues" data-aura-repo="aurajs/aura"&gt;&lt;/div&gt;
-  &lt;div class='span4' data-aura-widget="issues" data-aura-repo="emberjs/ember.js"&gt;&lt;/div&gt;
-  &lt;div class='span4' data-aura-widget="issues" data-aura-repo="documentcloud/backbone"&gt;&lt;/div&gt;
-&lt;/div&gt;
+  &lt;div class='span4' data-aura-widget="issues" data-aura-repo="aurajs/aura"&gt;&lt; &#47;div&gt;
+  &lt;div class='span4' data-aura-widget="issues" data-aura-repo="emberjs/ember.js"&gt;&lt; &#47;div&gt;
+  &lt;div class='span4' data-aura-widget="issues" data-aura-repo="documentcloud/backbone"&gt;&lt; &#47;div&gt;
+&lt; &#47;div&gt;
 </code></pre>
 
 <p>Any other widget can now emit <code>issues.filter</code>  events that these widgets will respond to.
@@ -318,7 +318,7 @@ This means that they know nothing about each other. To make them communicate, a 
 
 <p>Add the following code to your HTML document.</p>
 
-<pre><code class="html">&lt;div data-aura-widget=&quot;hello&quot;&gt;&lt;/div&gt;
+<pre><code class="html">&lt;div data-aura-widget=&quot;hello&quot;&gt;&lt; &#47;div&gt;
 </code></pre>
 
 <p>Aura will call the <code>initialize</code> method that we have defined in <code>widgets/hello/main.js</code>.</p>


### PR DESCRIPTION
Fixed div issue noted by @websam101 in [https://github.com/aurajs/aura/issues/268#issuecomment-20179767]

Also noted that when `&lt;&#47div&gt;` are together outcome is `>div>` that's why there is an extra space to workaround this.
