### PR TITLE
Some fixes and missing chars

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,11 +148,11 @@ app.start({ widgets: 'body' });
 
 <p><strong>widgets/issues/main.js</strong></p>
 
-<pre><code>define(['underscore', 'text!./issues.html'], function(_, tpl) {
+<pre><code class="js">define(['underscore', 'text!./issues.html'], function(_, tpl) {
 
   // Allow template to be overriden locally 
   // via a text/template script tag
-  var template, customTemplate = $('script['data-aura-template="github/issues"]');
+  var template, customTemplate = $('script[data-aura-template="github/issues"]');
   if (customTemplate.length &gt; 0) {
     template = _.template(customTemplate.html());
   } else {


### PR DESCRIPTION
I just fixed some typos I found while reading.
I also noticed that `<`s are removed if there's a char in front of them although the HTML entities (`&lt;`) are in the [code](https://github.com/aurajs/aura/blob/gh-pages/index.html#L194):

``` html
<div class='row'>
  <div class='span4' data-aura-widget="issues" data-aura-repo="aurajs/aura">div>
  <div class='span4' data-aura-widget="issues" data-aura-repo="emberjs/ember.js">div>
  <div class='span4' data-aura-widget="issues" data-aura-repo="documentcloud/backbone">div>
div>

<div data-aura-widget="hello">div>
```

``` javascript
define({
  initialize: function () {
    this.$el.html('<h1>Hello Aurah1>');
  }
});
```

Could this behavior be produced by some bad code highlighter?
