### PR TITLE
Update jquery to ~1.10.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "main": "lib/aura.js",
   "dependencies": {
     "jquery": "~1.10.x",
-    "underscore": "~1.4.4",
+    "underscore": "~1.5.x",
     "eventemitter2": "~0.4.11",
     "requirejs": "~2.1.4",
     "requirejs-text": "~2.0.5"


### PR DESCRIPTION
Update jquery to ~1.10.x as discussed in boilerplate's [PR #9](https://github.com/aurajs/boilerplate/pull/9). 

Sorry for the github/email spam lately.... :)

@sbellity: Should we update underscore to ~1.5.x before tagging?
