### PR TITLE
Harmonizes init of app.logger and sandbox.logger

### DIFF
--- a/lib/aura.js
+++ b/lib/aura.js
@@ -319,6 +319,11 @@ define([
     // Register core extensions : debug, mediator and components.
     config.debug = config.debug || {};
     var debug = config.debug;
+    if (debug === true) {
+      config.debug = debug = {
+        enable: true
+      };
+    }
     if (debug.enable) {
       if(debug.components){
         debug.components = debug.components.split(' ');

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,17 +9,23 @@ define([], function() {
     this._log   = noop;
     this._warn  = noop;
     this._error = noop;
+    this._enabled = false;
     return this;
   }
+
+  Logger.prototype.isEnabled = function () {
+    return this._enabled;
+  };
 
   Logger.prototype.setName = function(name){
     this.name = name;
   };
 
   Logger.prototype.enable = function() {
-    this._log   = (console.log   || noop);
-    this._warn  = (console.warn  || this._log);
-    this._error = (console.error || this._log);
+    this._log     = (console.log   || noop);
+    this._warn    = (console.warn  || this._log);
+    this._error   = (console.error || this._log);
+    this._enabled = true;
 
     if (Function.prototype.bind && typeof console === "object") {
       var logFns = ["log", "warn", "error"];

--- a/spec/lib/aura_spec.js
+++ b/spec/lib/aura_spec.js
@@ -117,6 +117,24 @@ define(['aura/aura'], function (aura) {
         sandbox.logger.log.should.be.a('function');
         sandbox.logger.name.should.equal(sandbox.ref);
       });
+
+      it('logger should be disabled by default', function() {
+        var App = aura();
+        var sandbox = App.sandboxes.create();
+        App.logger.isEnabled().should.not.be.ok;
+        sandbox.logger.isEnabled().should.not.be.ok;
+      });
+
+      it('logger should be initialized with options to the Aura constructor', function () {
+        var App1 = aura({debug: true});
+        var sandbox1 = App1.sandboxes.create();
+        App1.logger.isEnabled().should.be.ok;
+        sandbox1.logger.isEnabled().should.be.ok;
+        var App = aura({debug: {enable: true}});
+        var sandbox = App.sandboxes.create();
+        App.logger.isEnabled().should.be.ok;
+        sandbox.logger.isEnabled().should.be.ok;
+      });
     });
 
   });


### PR DESCRIPTION
The issue that this PR solves is as described:

When passing `{debug: {enable: true}}` to the `Aura` constructor, both the loggers attached to the sandboxes and the logger attached to the app would be started.

When passing `{debug: true}` to the `Aura` constructor, only the loggers in the sandboxes would be started.

This PR solves this and provides the related specs.
