### PR TITLE
Component.prototype.invokeWithCallback handles the correct signature

### DIFF
--- a/lib/ext/components.js
+++ b/lib/ext/components.js
@@ -99,7 +99,7 @@ define('aura/ext/components', function() {
        */
       this.$el        = core.dom.find(opts.el);
 
-      invokeWithCallbacks('initialize', this, this.options);
+      this.invokeWithCallbacks('initialize', this.options);
       return this;
     }
 
@@ -146,7 +146,7 @@ define('aura/ext/components', function() {
      * @return {Promise} a Promise that will resolve to the return value of the original function invoked.
      */
     Component.prototype.invokeWithCallbacks = function(methodName) {
-      invokeWithCallbacks(methodName, this);
+      return invokeWithCallbacks.apply(undefined, [methodName, this].concat([].slice.call(arguments, 1)));
     };
 
     // Stolen from Backbone 0.9.9 !
@@ -503,7 +503,7 @@ define('aura/ext/components', function() {
       },
 
       /**
-       * When all of an application's extensions are finally loaded, the 'extensions' 
+       * When all of an application's extensions are finally loaded, the 'extensions'
        * afterAppStart methods are then called.
        *
        * @method components.afterAppStart


### PR DESCRIPTION
The arguments and return value of `Component.prototype.invokeWithCallbacks` is now the same as the internal `invokeWithCallbacks`. It proxies all the arguments to the latter:
- it provides `this` as a context
- it returns a promise.
- it passes all the arguments.
