### PR TITLE
Updates to `after` callbacks

### DIFF
--- a/lib/ext/components.js
+++ b/lib/ext/components.js
@@ -50,14 +50,12 @@ define('aura/ext/components', function() {
       var dfd = app.core.data.deferred();
       var before, after, args = [].slice.call(arguments, 2);
       before = invokeCallbacks("before", fnName, context, args);
-      var result;
 
       before.then(function() {
-        var result =  fn.apply(context, args);
-        return result;
-      }).then(function() {
-        invokeCallbacks("after", fnName, context, args).then(function() {
-          dfd.resolve(result);
+        return fn.apply(context, args);
+      }).then(function(_res) {
+        return invokeCallbacks("after", fnName, context, args.concat(_res)).then(function() {
+          dfd.resolve(_res);
         }, dfd.reject);
       }).fail(function(err) {
         app.logger.error("Error in Component " + context.options.name + " " + fnName + " callback", err);


### PR DESCRIPTION
They take the return value of the interceptee as their last argument

Component::invokeWithCallbacks always returns the value of the interceptee
