### PR TITLE
Simplify an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ define(['hbs!./stats'], function(template) {
     },
     initialize: function() {
       this.render();
-      this.sandbox.on('tasks.stats', _.bind(this.render, this));
+      this.sandbox.on('tasks.stats', this.render, this);
     },
     render: function(stats) {
       this.html(template(stats || {}));


### PR DESCRIPTION
The third documented argument to `.on` is the context for the callback, so we don't need to use `_.bind` for this example
